### PR TITLE
fix: fix security configs so it redirects to list route after login

### DIFF
--- a/flow-in-app-theme-demo/src/main/java/com/vaadin/demo/apptheme/security/SecurityConfiguration.java
+++ b/flow-in-app-theme-demo/src/main/java/com/vaadin/demo/apptheme/security/SecurityConfiguration.java
@@ -74,7 +74,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 				// In-App theming resources:
 				"/themes/**",
-				"/fontawesome/**",
 
 				// the standard favicon URI
 				"/favicon.ico",
@@ -86,6 +85,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 				"/manifest.webmanifest",
 				"/sw.js",
 				"/offline.html",
+				"/icons/**",
+				"/images/**",
+				"/styles/**",
 
 				// (development mode) H2 debugging console
 				"/h2-console/**");


### PR DESCRIPTION
fix the previous changes to `SecurityConfiguration.java` 
which messed up the redirect behavior after login, it was  
showing the restricted resources instead of the `list` route. 